### PR TITLE
Update url for mapping

### DIFF
--- a/uniprot.py
+++ b/uniprot.py
@@ -82,7 +82,7 @@ def get_uniprot_id_mapping_pairs(
     else:
       s = session
     r = s.post(
-        'http://www.uniprot.org/mapping/', 
+        'https://www.uniprot.org/uploadlists/', 
          files={'file':StringIO(' '.join(seqids))}, 
          params={
           'from': from_type.upper(),


### PR DESCRIPTION
The url for mapping has changed from `http://www.uniprot.org/mapping/` to `https://www.uniprot.org/uploadlists/`.

The previous URL returned no results but on switching to the new one your package worked as expected.